### PR TITLE
Grammar fix on landing page

### DIFF
--- a/site/themes/hugo-theme-enterpriseready/layouts/index.html
+++ b/site/themes/hugo-theme-enterpriseready/layouts/index.html
@@ -77,7 +77,7 @@
         <h2 align="center">The EnterpriseReady SaaS Feature Guides</h2>
         <p align="center">Created for people who <strong>build</strong> SaaS products (founders, product managers and engineering team leads) to change the enterprise software narrative from "how to SELL to the enterprise" to <strong>"how to BUILD for the enterprise"</strong>. Based on study of the <a href="/blog/saas-feature-table">50 leading SaaS application product packages</a>, in-depth CIO interviews and feedback from countless SaaS founders.</p>
         <div style="height:0px; border-top: 1px solid #D6D6D6;margin:50px 0px"></div>
-        <h3 align="center">Is you app ready for enterprise buyers?</h3>
+        <h3 align="center">Is your app ready for enterprise buyers?</h3>
         <p align="center">Take our self-assessment to find out how ready your application is for enterprise adoption.</p>
         <p align="center"><a href="https://www.enterprisegrade.io" class="button button-primary" target="_blank">Take Assessment</a></p>
       </div>


### PR DESCRIPTION
The sub-heading "Is you app ready for enterprise buyers?" should read "Is **your** app ready for enterprise buyers?"